### PR TITLE
Update graphql_flutter version to 3.1.0 and fix deprecations

### DIFF
--- a/flutter-example/android/gradle.properties
+++ b/flutter-example/android/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 
+android.enableR8=true

--- a/flutter-example/lib/main.dart
+++ b/flutter-example/lib/main.dart
@@ -29,6 +29,9 @@ void main() {
     ),
   );
 
+// Wait for Servicebinding initialization
+  WidgetsFlutterBinding.ensureInitialized();
+
 // =========================================================
 // create a client with a link and a cache object
 // the Graphql library caches anything it can to improve

--- a/flutter-example/lib/screens/user_add_screen.dart
+++ b/flutter-example/lib/screens/user_add_screen.dart
@@ -136,8 +136,8 @@ class _UserAddScreenState extends State<UserAddScreen> {
         // =======================================
         // first, handle any errors
         // =======================================
-        if (result.hasErrors) {
-          return Text('${result.errors}');
+        if (result.hasException) {
+          return Text('${result.exception}');
         }
 
         // =======================================

--- a/flutter-example/lib/screens/users_screen.dart
+++ b/flutter-example/lib/screens/users_screen.dart
@@ -54,18 +54,19 @@ class QueryUsers extends StatelessWidget {
       }
     }
     ''';
+
   @override
   Widget build(BuildContext context) {
     return Query(
       options: QueryOptions(
         document: queryUsers,
       ),
-      builder: (QueryResult result, {VoidCallback refetch}) {
+      builder: (QueryResult result, {dynamic fetchMore, refetch}) {
         // ========================================================
         // HANDLE ERRORS
         // ========================================================
-        if (result.errors != null) {
-          return Text(result.errors.toString());
+        if (result.exception != null) {
+          return Text(result.exception.toString());
         }
 
         // ========================================================

--- a/flutter-example/pubspec.yaml
+++ b/flutter-example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  graphql_flutter: ^2.1.0
+  graphql_flutter: ^3.1.0
 
   cupertino_icons: ^0.1.2
 


### PR DESCRIPTION
Thank you for this nice example project.

I was not able to use this without upgrading `graphql_flutter` first, due to flutter API changes, but it was surprisingly easy to do,
so might as well make a pull request.